### PR TITLE
Add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The Services team owns this service and should be added as a reviewer on all pull requests.
+*       @harrystech/services

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+[Link to Jira ticket](https://harrys.atlassian.net/browse/STORY_ID)
+
+## Description - What Has Changed, and Why?
+
+Please include a summary of the change and relevant motivation and context.
+
+Where applicable, add related PRs, To-Dos, or Jira tickets.
+
+## Testing
+
+What automated tests were added or changed with this pull request.
+
+Document how someone could manually test that this code does what it is supposed to do.
+
+Include applicable links.
+
+## Risks
+
+Are there any known risks to deploying this code?
+
+## Checklist
+
+- [ ] Is all documentation around this code updated? (service-specific README, top-level summary, Swagger docs, etc.)
+- [ ] Are unit / e2e / integration tests written for this work, and do they pass the declared coverage % threshold (if that exists in this repository)? <!-- Build pipelines should cover for this case -->
+- [ ] Are there any breaking changes to the public API that impact consumers? If so, have the relevant parties been notified of these changes being released?

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # docker-crm-ci
+
+Docker image to be used when building CRM.


### PR DESCRIPTION
This adds the CODEOWNERS file and a PR template to get us closer to https://harrys.atlassian.net/wiki/spaces/EN/pages/2415493250/Configuring+GitHub+Repos

Note: This is a PUBLIC repo so that CI has easy access. (?)